### PR TITLE
Do not fail when reporting identifier macro errors.

### DIFF
--- a/src/compiler/expander/lowlevel.rkt
+++ b/src/compiler/expander/lowlevel.rkt
@@ -67,7 +67,7 @@
                             (map expand-instruction (cons first rest))
                             "Bad `asm` syntax"))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `asm` syntax, expected a list of assembly instructions to follow:")))))

--- a/src/compiler/expander/macros.rkt
+++ b/src/compiler/expander/macros.rkt
@@ -7,7 +7,7 @@
 (require "../errors.rkt")
 
 (require (only-in "syntax-forms.rkt"
-                  valid-bindings valid-symbol))
+                  valid-bindings valid-symbol offending-node))
 
 (provide (all-defined-out))
 
@@ -21,7 +21,7 @@
                              (make-ast-body loc (cons first rest) "Bad `when` body syntax")
                              (make-ast-symbol loc 'nil)))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `when` syntax, expected a condition and a body to follow:")))))
@@ -36,7 +36,7 @@
                              (make-ast-symbol loc 'nil)
                              (make-ast-body loc (cons first rest) "Bad `unless` body syntax")))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `unless` syntax, expected a condition and a body to follow:")))))
@@ -57,7 +57,7 @@
                                             (cons (ast-list-car expr)
                                                   rest))))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `cond` syntax, expected a list of conditional branches with a final else branch to follow:")))))
@@ -74,7 +74,7 @@
                           (make-ast-list loc (cons and rest))
                           (make-ast-symbol loc 'false)))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `and` syntax, expected a list of expressions to follow:")))))
@@ -91,7 +91,7 @@
                           (make-ast-symbol loc 'true)
                           (make-ast-list loc (cons or rest))))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `or` syntax, expected a list of expressions to follow:")))))
@@ -112,7 +112,7 @@
                                                    (make-ast-list loc rest-bindings) ;; FIXME Could use a better location.
                                                  body))))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `let*` syntax, expected a list of bindings and a body to follow:")))))
@@ -128,7 +128,7 @@
                                                     (list (valid-symbol name "Bad `letcc` syntax"))
                                                     (make-ast-body loc (cons first rest) "Bad `letcc` body syntax")))))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `letcc` syntax, expected an identifier and a body to follow:")))))
@@ -144,7 +144,7 @@
                                                     (list (valid-symbol name "Bad `shift` syntax"))
                                                     (make-ast-body loc (cons first rest) "Bad `shift` body syntax")))))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `shift` syntax, expected an identifier and a body to follow:")))))
@@ -160,7 +160,7 @@
                                                     '()
                                                     (make-ast-body loc (cons first rest) "Bad `reset` body syntax")))))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `reset` syntax, expected exactly one expression to follow:")))))
@@ -175,7 +175,7 @@
                              (list handler
                                    (make-ast-lambda loc '() subexpr))))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `handle` syntax, expected exactly two expressions to follow:")))))
@@ -198,7 +198,7 @@
                                                              names))))
                      "Bad `structure` syntax")))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `structure` syntax, expected a module specification followed by a body:")))))
@@ -246,7 +246,7 @@
                                                                     body))))
                 "Bad `module` syntax"))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `module` syntax, expected a module specification followed by a body:")))))

--- a/src/compiler/expander/syntax-forms.rkt
+++ b/src/compiler/expander/syntax-forms.rkt
@@ -8,6 +8,12 @@
 
 (provide (all-defined-out))
 
+(define (offending-node expr)
+  (match-ast expr
+   ((list s rest ...)
+    s)
+   (else expr)))
+
 (define (if-expander expr use-env def-env)
   (match-ast expr
    ((list (symbol 'if) condition then else)
@@ -17,7 +23,7 @@
                            then
                            else)))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `if` syntax, expected exactly three expressions - condition, then and else branches - to follow:")))))
@@ -30,7 +36,7 @@
                    (cons first rest)
                    "Bad `do` syntax"))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `do` syntax, expected at least one expression to follow:")))))
@@ -45,7 +51,7 @@
                                              (cons first rest)
                                              "Bad `lambda` body syntax"))))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `lambda` syntax, expected a formal arguments specification followed by a body:")))))
@@ -124,7 +130,7 @@
                    (cons first rest)
                    "Bad `let` body syntax"))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `let` syntax, expected a list of bindings followed by a body:")))))
@@ -143,7 +149,7 @@
                    (cons first rest)
                    "Bad `letrec` body syntax"))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `letrec` syntax, expected a list of bindings followed by a body:")))))
@@ -215,7 +221,7 @@
              (make-ast-quote (ast-node-location expr)
                              value)))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `quote` syntax, expected exactly one expression to follow:")))))
@@ -227,7 +233,7 @@
              (make-ast-quasiquote (ast-node-location expr)
                                   value)))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `quasiquote` syntax, expected exactly one expression to follow:")))))
@@ -239,7 +245,7 @@
              (make-ast-unquote (ast-node-location expr)
                                value)))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `unquote` syntax, expected exactly one expression to follow:")))))
@@ -251,7 +257,7 @@
              (make-ast-unquote-splicing (ast-node-location expr)
                                         value)))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `unquote-splicing` syntax, expected exactly one expression to follow:")))))
@@ -279,7 +285,7 @@
                            (valid-symbol name "Bad `define` syntax")
                             value)))
    (else
-    (let ((node (ast-list-car expr)))
+    (let ((node (offending-node expr)))
       (raise-compilation-error
        node
        "Bad `define` syntax, expected either an identifier and an expression or a function signature and a body to follow:")))))

--- a/test/data/errors/macros.sprtn
+++ b/test/data/errors/macros.sprtn
@@ -78,3 +78,15 @@
 (module (fazfoo bar)
   (define (foo x) (+ x bar)))
 foo bar baz faz foobar barbaz bazfaz fazfoo
+when
+unless
+cond
+and
+or
+let*
+letcc
+shift
+reset
+handle
+structure
+module

--- a/test/data/errors/syntax-forms.sprtn
+++ b/test/data/errors/syntax-forms.sprtn
@@ -80,3 +80,13 @@
 '(,@wat)
 `,bar
 `,@wat
+if
+do
+lambda
+let
+letrec
+quote
+quasiquote
+unquote
+unquote-splicing
+define

--- a/test/data/snapshots/macros.sprtn.output
+++ b/test/data/snapshots/macros.sprtn.output
@@ -323,4 +323,99 @@ test/data/errors/macros.sprtn(72,18): Undefined variable `z`, did you mean `*`:
  73 [33m|[39m (module (foobar) (define foo 5))
  74 [33m|[39m (module (barbaz) (define (foo x) x))
 
-Compilation aborted due to 41 errors.
+test/data/errors/macros.sprtn(81,0): Bad `when` syntax, expected a condition and a body to follow:
+ 79 [33m|[39m   (define (foo x) (+ x bar)))
+ 80 [33m|[39m foo bar baz faz foobar barbaz bazfaz fazfoo
+ 81 [33m|[39m when
+    [33m|[39m [31m^^^^[39m
+ 82 [33m|[39m unless
+ 83 [33m|[39m cond
+
+test/data/errors/macros.sprtn(82,0): Bad `unless` syntax, expected a condition and a body to follow:
+ 80 [33m|[39m foo bar baz faz foobar barbaz bazfaz fazfoo
+ 81 [33m|[39m when
+ 82 [33m|[39m unless
+    [33m|[39m [31m^^^^^^[39m
+ 83 [33m|[39m cond
+ 84 [33m|[39m and
+
+test/data/errors/macros.sprtn(83,0): Bad `cond` syntax, expected a list of conditional branches with a final else branch to follow:
+ 81 [33m|[39m when
+ 82 [33m|[39m unless
+ 83 [33m|[39m cond
+    [33m|[39m [31m^^^^[39m
+ 84 [33m|[39m and
+ 85 [33m|[39m or
+
+test/data/errors/macros.sprtn(84,0): Bad `and` syntax, expected a list of expressions to follow:
+ 82 [33m|[39m unless
+ 83 [33m|[39m cond
+ 84 [33m|[39m and
+    [33m|[39m [31m^^^[39m
+ 85 [33m|[39m or
+ 86 [33m|[39m let*
+
+test/data/errors/macros.sprtn(85,0): Bad `or` syntax, expected a list of expressions to follow:
+ 83 [33m|[39m cond
+ 84 [33m|[39m and
+ 85 [33m|[39m or
+    [33m|[39m [31m^^[39m
+ 86 [33m|[39m let*
+ 87 [33m|[39m letcc
+
+test/data/errors/macros.sprtn(86,0): Bad `let*` syntax, expected a list of bindings and a body to follow:
+ 84 [33m|[39m and
+ 85 [33m|[39m or
+ 86 [33m|[39m let*
+    [33m|[39m [31m^^^^[39m
+ 87 [33m|[39m letcc
+ 88 [33m|[39m shift
+
+test/data/errors/macros.sprtn(87,0): Bad `letcc` syntax, expected an identifier and a body to follow:
+ 85 [33m|[39m or
+ 86 [33m|[39m let*
+ 87 [33m|[39m letcc
+    [33m|[39m [31m^^^^^[39m
+ 88 [33m|[39m shift
+ 89 [33m|[39m reset
+
+test/data/errors/macros.sprtn(88,0): Bad `shift` syntax, expected an identifier and a body to follow:
+ 86 [33m|[39m let*
+ 87 [33m|[39m letcc
+ 88 [33m|[39m shift
+    [33m|[39m [31m^^^^^[39m
+ 89 [33m|[39m reset
+ 90 [33m|[39m handle
+
+test/data/errors/macros.sprtn(89,0): Bad `reset` syntax, expected exactly one expression to follow:
+ 87 [33m|[39m letcc
+ 88 [33m|[39m shift
+ 89 [33m|[39m reset
+    [33m|[39m [31m^^^^^[39m
+ 90 [33m|[39m handle
+ 91 [33m|[39m structure
+
+test/data/errors/macros.sprtn(90,0): Bad `handle` syntax, expected exactly two expressions to follow:
+ 88 [33m|[39m shift
+ 89 [33m|[39m reset
+ 90 [33m|[39m handle
+    [33m|[39m [31m^^^^^^[39m
+ 91 [33m|[39m structure
+ 92 [33m|[39m module
+
+test/data/errors/macros.sprtn(91,0): Bad `structure` syntax, expected a module specification followed by a body:
+ 89 [33m|[39m reset
+ 90 [33m|[39m handle
+ 91 [33m|[39m structure
+    [33m|[39m [31m^^^^^^^^^[39m
+ 92 [33m|[39m module
+ 93 [33m|[39m 
+
+test/data/errors/macros.sprtn(92,0): Bad `module` syntax, expected a module specification followed by a body:
+ 90 [33m|[39m handle
+ 91 [33m|[39m structure
+ 92 [33m|[39m module
+    [33m|[39m [31m^^^^^^[39m
+ 93 [33m|[39m 
+
+Compilation aborted due to 53 errors.

--- a/test/data/snapshots/syntax-forms.sprtn.output
+++ b/test/data/snapshots/syntax-forms.sprtn.output
@@ -520,6 +520,86 @@ test/data/errors/syntax-forms.sprtn(82,1): Misplaced `unquote-splicing`, expecte
  81 [33m|[39m `,bar
  82 [33m|[39m `,@wat
     [33m|[39m  [31m^^^^^[39m
- 83 [33m|[39m 
+ 83 [33m|[39m if
+ 84 [33m|[39m do
 
-Compilation aborted due to 66 errors.
+test/data/errors/syntax-forms.sprtn(83,0): Bad `if` syntax, expected exactly three expressions - condition, then and else branches - to follow:
+ 81 [33m|[39m `,bar
+ 82 [33m|[39m `,@wat
+ 83 [33m|[39m if
+    [33m|[39m [31m^^[39m
+ 84 [33m|[39m do
+ 85 [33m|[39m lambda
+
+test/data/errors/syntax-forms.sprtn(84,0): Bad `do` syntax, expected at least one expression to follow:
+ 82 [33m|[39m `,@wat
+ 83 [33m|[39m if
+ 84 [33m|[39m do
+    [33m|[39m [31m^^[39m
+ 85 [33m|[39m lambda
+ 86 [33m|[39m let
+
+test/data/errors/syntax-forms.sprtn(85,0): Bad `lambda` syntax, expected a formal arguments specification followed by a body:
+ 83 [33m|[39m if
+ 84 [33m|[39m do
+ 85 [33m|[39m lambda
+    [33m|[39m [31m^^^^^^[39m
+ 86 [33m|[39m let
+ 87 [33m|[39m letrec
+
+test/data/errors/syntax-forms.sprtn(86,0): Bad `let` syntax, expected a list of bindings followed by a body:
+ 84 [33m|[39m do
+ 85 [33m|[39m lambda
+ 86 [33m|[39m let
+    [33m|[39m [31m^^^[39m
+ 87 [33m|[39m letrec
+ 88 [33m|[39m quote
+
+test/data/errors/syntax-forms.sprtn(87,0): Bad `letrec` syntax, expected a list of bindings followed by a body:
+ 85 [33m|[39m lambda
+ 86 [33m|[39m let
+ 87 [33m|[39m letrec
+    [33m|[39m [31m^^^^^^[39m
+ 88 [33m|[39m quote
+ 89 [33m|[39m quasiquote
+
+test/data/errors/syntax-forms.sprtn(88,0): Bad `quote` syntax, expected exactly one expression to follow:
+ 86 [33m|[39m let
+ 87 [33m|[39m letrec
+ 88 [33m|[39m quote
+    [33m|[39m [31m^^^^^[39m
+ 89 [33m|[39m quasiquote
+ 90 [33m|[39m unquote
+
+test/data/errors/syntax-forms.sprtn(89,0): Bad `quasiquote` syntax, expected exactly one expression to follow:
+ 87 [33m|[39m letrec
+ 88 [33m|[39m quote
+ 89 [33m|[39m quasiquote
+    [33m|[39m [31m^^^^^^^^^^[39m
+ 90 [33m|[39m unquote
+ 91 [33m|[39m unquote-splicing
+
+test/data/errors/syntax-forms.sprtn(90,0): Bad `unquote` syntax, expected exactly one expression to follow:
+ 88 [33m|[39m quote
+ 89 [33m|[39m quasiquote
+ 90 [33m|[39m unquote
+    [33m|[39m [31m^^^^^^^[39m
+ 91 [33m|[39m unquote-splicing
+ 92 [33m|[39m define
+
+test/data/errors/syntax-forms.sprtn(91,0): Bad `unquote-splicing` syntax, expected exactly one expression to follow:
+ 89 [33m|[39m quasiquote
+ 90 [33m|[39m unquote
+ 91 [33m|[39m unquote-splicing
+    [33m|[39m [31m^^^^^^^^^^^^^^^^[39m
+ 92 [33m|[39m define
+ 93 [33m|[39m 
+
+test/data/errors/syntax-forms.sprtn(92,0): Bad `define` syntax, expected either an identifier and an expression or a function signature and a body to follow:
+ 90 [33m|[39m unquote
+ 91 [33m|[39m unquote-splicing
+ 92 [33m|[39m define
+    [33m|[39m [31m^^^^^^[39m
+ 93 [33m|[39m 
+
+Compilation aborted due to 76 errors.


### PR DESCRIPTION
Fixes #179 